### PR TITLE
Show description summary instead of bulleted details

### DIFF
--- a/lib/event.rb
+++ b/lib/event.rb
@@ -1,5 +1,5 @@
 class Event
-  DESCRIPTION_ELEMENT_ID = "what-will-i-learn"
+  DESCRIPTION_ELEMENT_ID = "summary"
 
   def initialize(details)
     @details = details
@@ -12,11 +12,11 @@ class Event
   def description
     content = html_node_for(full_description).first
 
-    content.traverse do |node|
-      node.delete "style"
+    if content
+      clear_styles_in_html(content)
+    else
+      "More details to come."
     end
-
-    content.inner_html
   end
 
   def dates
@@ -48,6 +48,14 @@ class Event
 
   def full_description
     details["description"]
+  end
+
+  def clear_styles_in_html(content)
+    content.traverse do |node|
+      node.delete "style"
+    end
+
+    content.inner_html
   end
 
   def start_date

--- a/spec/lib/event_spec.rb
+++ b/spec/lib/event_spec.rb
@@ -5,7 +5,7 @@ require "venue"
 describe Event do
   describe "#description" do
     it "returns the workshop content portion of the event description" do
-      stub_const("Event::DESCRIPTION_ELEMENT_ID", "somewhere")
+      set_description_id_to
       description_html = '<b>Some</b> stuff'
       event = Event.new(event_with_description(description_html))
 
@@ -13,11 +13,24 @@ describe Event do
     end
 
     it "clears out any styles" do
-      stub_const("Event::DESCRIPTION_ELEMENT_ID", "somewhere")
+      set_description_id_to
       description_html = '<span style="color: red">Some</span> stuff'
       event = Event.new(event_with_description(description_html))
 
       expect(event.description).to eq('<span>Some</span> stuff')
+    end
+
+    context "when there is no description set" do
+      it "returns placeholder text" do
+        description_html = '<span style="color: red">Some</span> stuff'
+        event = Event.new("description" => description_html)
+
+        expect(event.description).to eq("More details to come.")
+      end
+    end
+
+    def set_description_id_to
+      stub_const("Event::DESCRIPTION_ELEMENT_ID", "somewhere")
     end
 
     def event_with_description(content)


### PR DESCRIPTION
When there is no description available, we'll show some placeholder text.
