### PR TITLE
Cache responses from Eventbrite API

### DIFF
--- a/app/helpers/events_helper.rb
+++ b/app/helpers/events_helper.rb
@@ -10,6 +10,6 @@ module EventsHelper
   private
 
   def event_manager
-    Eventbrite.new
+    @event_manager ||= Eventbrite.new
   end
 end

--- a/lib/eventbrite.rb
+++ b/lib/eventbrite.rb
@@ -28,7 +28,7 @@ class Eventbrite
   end
 
   def user_events_response
-    self.class.get(
+    @user_events_response ||= self.class.get(
       events_owned_by_user_api_url,
       query: credentials.merge(event_criteria)
     )
@@ -45,7 +45,7 @@ class Eventbrite
   end
 
   def user_response
-    self.class.get(user_profile_api_url, query: credentials)
+    @user_response ||= self.class.get(user_profile_api_url, query: credentials)
   end
 
   def user_profile_api_url


### PR DESCRIPTION
This takes the number of GET requests for the homepage from 63 (!!) to 2.