### PR TITLE
Simplify how we specify dependencies

### DIFF
--- a/lib/eventbrite/event.rb
+++ b/lib/eventbrite/event.rb
@@ -1,3 +1,5 @@
+require "eventbrite/venue"
+
 module Eventbrite
   class Event
     def initialize(details)

--- a/lib/eventbrite/event_finder.rb
+++ b/lib/eventbrite/event_finder.rb
@@ -1,4 +1,5 @@
 require "eventbrite/finder"
+require "eventbrite/event"
 require "eventbrite/null_event"
 
 module Eventbrite

--- a/lib/eventbrite/null_event.rb
+++ b/lib/eventbrite/null_event.rb
@@ -1,3 +1,5 @@
+require "ostruct"
+
 module Eventbrite
   class NullEvent
     def title

--- a/spec/lib/eventbrite/event_finder_spec.rb
+++ b/spec/lib/eventbrite/event_finder_spec.rb
@@ -1,8 +1,6 @@
+require "spec_helper"
 require "climate_control"
-require "json"
-require "webmock/rspec"
 require "eventbrite/event_finder"
-require "eventbrite/event"
 
 describe Eventbrite::EventFinder do
   around do |example|

--- a/spec/lib/eventbrite/event_spec.rb
+++ b/spec/lib/eventbrite/event_spec.rb
@@ -1,5 +1,4 @@
 require "eventbrite/event"
-require "eventbrite/venue"
 
 describe Eventbrite::Event do
   describe "#dates" do

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -1,7 +1,7 @@
 ENV["RAILS_ENV"] = "test"
 
 require File.expand_path("../../config/environment", __FILE__)
-
+require "spec_helper"
 require "rspec/rails"
 
 Dir[Rails.root.join("spec/support/**/*.rb")].each { |file| require file }


### PR DESCRIPTION
Each class and their correspending unit specs should really only have to specify
dependencies that are directly related to them without having to reach too far.
For example, the `EventFinder` spec should only have to require the file
containing its class and nothing else that the class itself actually depends on,
like `Eventbrite::Event`.

On the other hand, we could also move some spec config over to the
`spec_helper.rb` file and have `rails_helper` refer to it, so that that can be
centralized and shared across all tests.

Addresses #40