### PR TITLE
Introduce VenueFinder

### DIFF
--- a/lib/eventbrite/event.rb
+++ b/lib/eventbrite/event.rb
@@ -1,4 +1,4 @@
-require "eventbrite/venue"
+require "eventbrite/venue_finder"
 
 module Eventbrite
   class Event
@@ -22,7 +22,7 @@ module Eventbrite
     end
 
     def venue
-      Eventbrite::Venue.new(venue_details)
+      @venue ||= Eventbrite::VenueFinder.find(venue_id)
     end
 
     private
@@ -37,8 +37,8 @@ module Eventbrite
       details["end"]["local"]
     end
 
-    def venue_details
-      details["venue"] ||= {}
+    def venue_id
+      details["venue_id"] ||= ""
     end
   end
 end

--- a/lib/eventbrite/null_venue.rb
+++ b/lib/eventbrite/null_venue.rb
@@ -1,0 +1,11 @@
+module Eventbrite
+  class NullVenue
+    def name
+      "Location TBD"
+    end
+
+    def address
+      ""
+    end
+  end
+end

--- a/lib/eventbrite/venue.rb
+++ b/lib/eventbrite/venue.rb
@@ -5,7 +5,7 @@ module Eventbrite
     end
 
     def name
-      details["name"] ||= "Location TBD"
+      details["name"] ||= ""
     end
 
     def address

--- a/lib/eventbrite/venue_finder.rb
+++ b/lib/eventbrite/venue_finder.rb
@@ -1,0 +1,29 @@
+require "eventbrite/finder"
+require "eventbrite/venue"
+require "eventbrite/null_venue"
+
+module Eventbrite
+  class VenueFinder < Finder
+    def find
+      if venue_response.success?
+        Eventbrite::Venue.new(venue_details)
+      else
+        Eventbrite::NullVenue.new
+      end
+    end
+
+    private
+
+    def venue_details
+      JSON.parse(venue_response.body)
+    end
+
+    def venue_response
+      response_for(venue_path)
+    end
+
+    def venue_path
+      "/venues/#{id}"
+    end
+  end
+end

--- a/spec/features/hide_registration_spec.rb
+++ b/spec/features/hide_registration_spec.rb
@@ -37,9 +37,11 @@ feature "Hiding registration" do
       "url" => "http://example.com",
       "start" => { "local" => "2014-09-19" },
       "end" => { "local" => "2014-09-20" },
-      "venue" => { "name" => venue_name },
+      "venue_id" => "123",
     )
+    venue = Eventbrite::Venue.new("name" => venue_name)
 
     allow(Eventbrite::EventFinder).to receive(:find).and_return(upcoming_event)
+    allow(Eventbrite::VenueFinder).to receive(:find).and_return(venue)
   end
 end

--- a/spec/lib/eventbrite/event_finder_spec.rb
+++ b/spec/lib/eventbrite/event_finder_spec.rb
@@ -1,8 +1,11 @@
 require "spec_helper"
 require "climate_control"
 require "eventbrite/event_finder"
+require "support/eventbrite_helpers"
 
 describe Eventbrite::EventFinder do
+  include EventbriteHelpers
+
   around do |example|
     env_variables = { EVENTBRITE_ACCESS_TOKEN: "bar", NEXT_EVENT_ID: "123" }
 
@@ -16,7 +19,11 @@ describe Eventbrite::EventFinder do
       it "returns an event object" do
         allow(Eventbrite::Event).to receive(:new)
         event_body = { "name" => { "text" => "event info" } }
-        stub_eventbrite_response(body: event_body, status: 200)
+        stub_eventbrite_response(
+          endpoint: "event",
+          body: event_body,
+          status: 200
+        )
 
         Eventbrite::EventFinder.find("123")
 
@@ -26,24 +33,16 @@ describe Eventbrite::EventFinder do
 
     context "when there's a bad response" do
       it "returns a placeholder event" do
-        stub_eventbrite_response(body: { id: "123" }, status: 500)
+        stub_eventbrite_response(
+          endpoint: "event",
+          body: { id: "123" },
+          status: 500
+        )
 
         event = Eventbrite::EventFinder.find("123")
 
         expect(event).to be_an(Eventbrite::NullEvent)
       end
-    end
-
-    def stub_eventbrite_response(body:, status:)
-      stub_request(:get, eventbrite_api_url).to_return(
-        headers: { "Content-Type" => "application/json" },
-        body: body.to_json,
-        status: status
-      )
-    end
-
-    def eventbrite_api_url
-      /eventbriteapi.com/
     end
   end
 end

--- a/spec/lib/eventbrite/event_spec.rb
+++ b/spec/lib/eventbrite/event_spec.rb
@@ -14,23 +14,15 @@ describe Eventbrite::Event do
   end
 
   describe "#venue" do
-    it "returns the venue of the event" do
-      details = { "venue" => "some event info" }
+    it "finds the venue based on the venue id" do
+      venue = double(:venue)
+      allow(Eventbrite::VenueFinder).to receive(:find).and_return(venue)
+      details = { "title" => "Event with no venue" }
+
       event = Eventbrite::Event.new(details)
-      expect(event.venue).to be_an(Eventbrite::Venue)
-    end
 
-    context "when there is no venue" do
-      it "creates an Eventbrite::Venue with an empty hash" do
-        venue = double(:venue)
-        allow(Eventbrite::Venue).to receive(:new).and_return(venue)
-        details = { "title" => "Event with no venue" }
-
-        event = Eventbrite::Event.new(details)
-
-        expect(event.venue).to eq(venue)
-        expect(Eventbrite::Venue).to have_received(:new).with({})
-      end
+      expect(event.venue).to eq(venue)
+      expect(Eventbrite::VenueFinder).to have_received(:find).with("")
     end
   end
 end

--- a/spec/lib/eventbrite/null_venue_spec.rb
+++ b/spec/lib/eventbrite/null_venue_spec.rb
@@ -1,0 +1,18 @@
+require "spec_helper"
+require "eventbrite/null_venue"
+
+describe Eventbrite::NullVenue do
+  describe "#name" do
+    it "returns 'Location TBD'" do
+      venue = Eventbrite::NullVenue.new
+      expect(venue.name).to eq("Location TBD")
+    end
+  end
+
+  describe "#address" do
+    it "returns an empty string" do
+      venue = Eventbrite::NullVenue.new
+      expect(venue.address).to be_empty
+    end
+  end
+end

--- a/spec/lib/eventbrite/venue_finder_spec.rb
+++ b/spec/lib/eventbrite/venue_finder_spec.rb
@@ -1,0 +1,49 @@
+require "spec_helper"
+require "climate_control"
+require "eventbrite/venue_finder"
+
+describe Eventbrite::VenueFinder do
+  around do |example|
+    env_variables = { EVENTBRITE_ACCESS_TOKEN: "bar", }
+
+    ClimateControl.modify env_variables do
+      example.run
+    end
+  end
+
+  describe ".find" do
+    context "when there's a successful response" do
+      it "returns an venue object" do
+        allow(Eventbrite::Venue).to receive(:new)
+        venue_body = { "name" => "Coolest Place" }
+        stub_eventbrite_response(body: venue_body, status: 200)
+
+        Eventbrite::VenueFinder.find("123")
+
+        expect(Eventbrite::Venue).to have_received(:new).with(venue_body)
+      end
+    end
+
+    context "when there's a bad response" do
+      it "returns a placeholder venue" do
+        stub_eventbrite_response(body: { id: "123" }, status: 500)
+
+        venue = Eventbrite::VenueFinder.find("123")
+
+        expect(venue).to be_an(Eventbrite::NullVenue)
+      end
+    end
+
+    def stub_eventbrite_response(body:, status:)
+      stub_request(:get, eventbrite_api_url).to_return(
+        headers: { "Content-Type" => "application/json" },
+        body: body.to_json,
+        status: status
+      )
+    end
+
+    def eventbrite_api_url
+      /eventbriteapi.com/
+    end
+  end
+end

--- a/spec/lib/eventbrite/venue_finder_spec.rb
+++ b/spec/lib/eventbrite/venue_finder_spec.rb
@@ -1,8 +1,11 @@
 require "spec_helper"
 require "climate_control"
 require "eventbrite/venue_finder"
+require "support/eventbrite_helpers"
 
 describe Eventbrite::VenueFinder do
+  include EventbriteHelpers
+
   around do |example|
     env_variables = { EVENTBRITE_ACCESS_TOKEN: "bar", }
 
@@ -16,7 +19,11 @@ describe Eventbrite::VenueFinder do
       it "returns an venue object" do
         allow(Eventbrite::Venue).to receive(:new)
         venue_body = { "name" => "Coolest Place" }
-        stub_eventbrite_response(body: venue_body, status: 200)
+        stub_eventbrite_response(
+          endpoint: "venue",
+          body: venue_body,
+          status: 200
+        )
 
         Eventbrite::VenueFinder.find("123")
 
@@ -26,24 +33,16 @@ describe Eventbrite::VenueFinder do
 
     context "when there's a bad response" do
       it "returns a placeholder venue" do
-        stub_eventbrite_response(body: { id: "123" }, status: 500)
+        stub_eventbrite_response(
+          endpoint: "venue",
+          body: { id: "123" },
+          status: 500
+        )
 
         venue = Eventbrite::VenueFinder.find("123")
 
         expect(venue).to be_an(Eventbrite::NullVenue)
       end
-    end
-
-    def stub_eventbrite_response(body:, status:)
-      stub_request(:get, eventbrite_api_url).to_return(
-        headers: { "Content-Type" => "application/json" },
-        body: body.to_json,
-        status: status
-      )
-    end
-
-    def eventbrite_api_url
-      /eventbriteapi.com/
     end
   end
 end

--- a/spec/lib/eventbrite/venue_spec.rb
+++ b/spec/lib/eventbrite/venue_spec.rb
@@ -9,10 +9,10 @@ describe Eventbrite::Venue do
     end
 
     context "when there is no venue name" do
-      it "returns 'Location TBD'" do
+      it "returns an empty string" do
         details = { "name" => nil }
         venue = Eventbrite::Venue.new(details)
-        expect(venue.name).to eq("Location TBD")
+        expect(venue.name).to be_empty
       end
     end
   end

--- a/spec/support/eventbrite_helpers.rb
+++ b/spec/support/eventbrite_helpers.rb
@@ -1,0 +1,15 @@
+module EventbriteHelpers
+  def stub_eventbrite_response(endpoint:, body:, status:)
+    path = eventbrite_api_url_with(endpoint)
+
+    stub_request(:get, path).to_return(
+      headers: { "Content-Type" => "application/json" },
+      body: body.to_json,
+      status: status
+    )
+  end
+
+  def eventbrite_api_url_with(pattern)
+    %r{eventbriteapi.com/.*#{pattern}}
+  end
+end


### PR DESCRIPTION
Venue details are no longer embedded into the event object response we get from
Eventbrite. Instead, they're giving us the venue id, which means we'd have to
fetch the venue details ourselves.

Changes also include extracting some EB API request helpers.